### PR TITLE
chore: byte-buddy in sample is unused.

### DIFF
--- a/samples/snippets/cloud-client/src/pom.xml
+++ b/samples/snippets/cloud-client/src/pom.xml
@@ -114,11 +114,6 @@
       <version>2.6.0</version>
     </dependency>
     <dependency>
-      <groupId>net.bytebuddy</groupId>
-      <artifactId>byte-buddy</artifactId>
-      <version>1.12.2</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>api-common</artifactId>
     </dependency>


### PR DESCRIPTION
The directory structure doesn't follow Maven's structure.

```
~/java-recaptchaenterprise/samples/snippets $ ls
cloud-client pom.xml
~/java-recaptchaenterprise/samples/snippets $ ls cloud-client
src
```

What is this "cloud-client" directory (without a pom.xml?)



```
~/java-recaptchaenterprise/samples/snippets $ mvn install
...

[INFO] --- maven-install-plugin:2.4:install (default-install) @ recaptcha-enterprise-snippets ---
[INFO] Installing /Users/suztomo/java-recaptchaenterprise/samples/snippets/target/recaptcha-enterprise-snippets-1.0.23.jar to /Users/suztomo/.m2/repository/com/google/cloud/recaptcha-enterprise-snippets/1.0.23/recaptcha-enterprise-snippets-1.0.23.jar
...
~/java-recaptchaenterprise/samples/snippets $ jar tf /Users/suztomo/.m2/repository/com/google/cloud/recaptcha-enterprise-snippets/1.0.23/recaptcha-enterprise-snippets-1.0.23.jar
META-INF/
META-INF/MANIFEST.MF
META-INF/maven/
META-INF/maven/com.google.cloud/
META-INF/maven/com.google.cloud/recaptcha-enterprise-snippets/
META-INF/maven/com.google.cloud/recaptcha-enterprise-snippets/pom.xml
META-INF/maven/com.google.cloud/recaptcha-enterprise-snippets/pom.properties
```