### PR TITLE
fix: enable longpaths support for windows test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,8 @@ jobs:
   windows:
     runs-on: windows-latest
     steps:
+    - name: Support longpaths
+      run: git config --system core.longpaths true
     - uses: actions/checkout@v3
     - uses: actions/setup-java@v3
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,8 +39,6 @@ jobs:
   windows:
     runs-on: windows-latest
     steps:
-    - name: Support longpaths
-      run: git config --system core.longpaths true
     - uses: actions/checkout@v3
     - uses: actions/setup-java@v3
       with:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:25.4.0')
+implementation platform('com.google.cloud:libraries-bom:26.0.0')
 
 implementation 'com.google.cloud:google-cloud-recaptchaenterprise'
 ```

--- a/owlbot.py
+++ b/owlbot.py
@@ -21,7 +21,4 @@ for library in s.get_staging_dirs():
     s.move(library)
 
 s.remove_staging_dirs()
-java.common_templates(excludes=[
-    # todo: remove once confirmed windows test fix works
-    '.github/workflows/ci.yaml'
-])
+java.common_templates()

--- a/owlbot.py
+++ b/owlbot.py
@@ -21,4 +21,7 @@ for library in s.get_staging_dirs():
     s.move(library)
 
 s.remove_staging_dirs()
-java.common_templates()
+java.common_templates(excludes=[
+    # todo: remove once confirmed windows test fix works
+    '.github/workflows/ci.yaml'
+])


### PR DESCRIPTION
Some tests are failing because the generated snippet files are using names that are longer than the standard 260 characters. This should enable usage of names that are longer than 260 characters. 
